### PR TITLE
fix: support array parameter e.g `v.isIn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ app.post(
     body: {
       // Pass the parameters to the validator using array:
       name: [v.isAlpha, [v.contains, 'abc']],
+      pref: [v.required, [v.isIn, ['valid', 'also_valid']]],
     },
     header: {
       'x-custom-header': v.isAlphanumeric,

--- a/deno_dist/README.md
+++ b/deno_dist/README.md
@@ -78,6 +78,7 @@ app.post(
     body: {
       // Pass the parameters to the validator using array:
       name: [v.isAlpha, [v.contains, 'abc']],
+      pref: [v.required, [v.isIn, ['valid', 'also_valid']]],
     },
     header: {
       'x-custom-header': v.isAlphanumeric,

--- a/deno_dist/index.ts
+++ b/deno_dist/index.ts
@@ -3,7 +3,7 @@ import { JSONPath } from "https://esm.sh/jsonpath-plus@7.0.0"
 import validator from './validator.ts'
 export type Validator = typeof validator
 
-type Param = string | number | Record<string, string | number> | Message
+type Param = string | number | string[] | number[] | Record<string, string | number> | Message
 type Rule = Function | [Function, ...Param[]]
 type Rules = Rule | Rule[]
 type Done = (resultSet: ResultSet, context: Context) => Response | undefined
@@ -78,8 +78,15 @@ const validatorMiddleware = (
             results[count - 1].params.push(rules)
           }
         } else {
-          for (const rule of rules) {
-            check(rule as Rules)
+          // [v.isIn, ['valid', 'also_valid']]
+          if (typeof rules[0] === ('string' || 'number')) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            results[count - 1].params.push(rules)
+          } else {
+            for (const rule of rules) {
+              check(rule as Rules)
+            }
           }
         }
       }

--- a/deno_test/index.test.ts
+++ b/deno_test/index.test.ts
@@ -60,4 +60,26 @@ Deno.test('Validator Middleware', async () => {
 
   res = await app.request(req)
   assertEquals(res.status, 400)
+
+  // Array parameter
+  app.post(
+    '/array-parameter',
+    validation((v) => ({
+      json: {
+        value: [v.required, [v.isIn, ['valid', 'also_valid']]],
+      },
+    })),
+    (c) => {
+      return c.text('Valid')
+    }
+  )
+
+  req = new Request('http://localhost/array-parameter', {
+    method: 'POST',
+    body: JSON.stringify({
+      value: 'invalid',
+    }),
+  })
+  res = await app.request(req)
+  assertEquals(res.status, 400)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { JSONPath } from 'jsonpath-plus'
 import validator from './validator'
 export type Validator = typeof validator
 
-type Param = string | number | Record<string, string | number> | Message
+type Param = string | number | string[] | number[] | Record<string, string | number> | Message
 type Rule = Function | [Function, ...Param[]]
 type Rules = Rule | Rule[]
 type Done = (resultSet: ResultSet, context: Context) => Response | undefined
@@ -78,8 +78,15 @@ const validatorMiddleware = (
             results[count - 1].params.push(rules)
           }
         } else {
-          for (const rule of rules) {
-            check(rule as Rules)
+          // [v.isIn, ['valid', 'also_valid']]
+          if (typeof rules[0] === ('string' || 'number')) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            results[count - 1].params.push(rules)
+          } else {
+            for (const rule of rules) {
+              check(rule as Rules)
+            }
           }
         }
       }


### PR DESCRIPTION
Support array parameters that are used in such `v.isIn`. Now, you can like below:

```ts
app.post(
  '/',
  validation((v) => ({
    body: {
      value: [v.required, [v.isIn, ['valid', 'also_valid']]],
    },
  })),
  (c) => {
    return c.text('Valid')
  }
)
```

Fix #6