### PR TITLE
fix: make it clone request when validates JSON/body

### DIFF
--- a/deno_dist/index.ts
+++ b/deno_dist/index.ts
@@ -138,7 +138,8 @@ const validatorMiddleware = (
 
     if (v.body) {
       const field = v.body
-      const parsedBody = (await c.req.parseBody()) as Record<string, string>
+      const req = c.req.clone()
+      const parsedBody = (await req.parseBody()) as Record<string, string>
       Object.keys(field).map(async (key) => {
         const value = parsedBody[key]
         const message = (name: string) =>
@@ -149,7 +150,8 @@ const validatorMiddleware = (
 
     if (v.json) {
       const field = v.json
-      const json = (await c.req.json()) as object
+      const req = c.req.clone()
+      const json = (await req.json()) as object
       Object.keys(field).map(async (key) => {
         const data = JSONPath({ path: key, json })
         const value = `${data[0]}` // Force converting to string

--- a/deno_test/index.test.ts
+++ b/deno_test/index.test.ts
@@ -82,4 +82,28 @@ Deno.test('Validator Middleware', async () => {
   })
   res = await app.request(req)
   assertEquals(res.status, 400)
+
+  // Confirm it clone the Request object
+  app.post(
+    '/json',
+    validation((v) => ({
+      json: {
+        value: v.required,
+      },
+    })),
+    async (c) => {
+      const json = (await c.req.json()) as { value: string }
+      return c.text(json.value)
+    }
+  )
+  const json = {
+    value: 'foo',
+  }
+  req = new Request('http://localhost/json', {
+    method: 'POST',
+    body: JSON.stringify(json),
+  })
+  res = await app.request(req)
+  assertEquals(res.status, 200)
+  assertEquals(await res.text(), 'foo')
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,8 @@ const validatorMiddleware = (
 
     if (v.body) {
       const field = v.body
-      const parsedBody = (await c.req.parseBody()) as Record<string, string>
+      const req = c.req.clone()
+      const parsedBody = (await req.parseBody()) as Record<string, string>
       Object.keys(field).map(async (key) => {
         const value = parsedBody[key]
         const message = (name: string) =>
@@ -149,7 +150,8 @@ const validatorMiddleware = (
 
     if (v.json) {
       const field = v.json
-      const json = (await c.req.json()) as object
+      const req = c.req.clone()
+      const json = (await req.json()) as object
       Object.keys(field).map(async (key) => {
         const data = JSONPath({ path: key, json })
         const value = `${data[0]}` // Force converting to string


### PR DESCRIPTION
The code below will cause the error. Fixed it.

```ts
app.post(
  '/json',
  validation((v) => ({
    json: {
      value: v.required,
    },
  })),
  async (c) => {
    const json = (await c.req.json()) as { value: string } // <--- using body
    return c.text(json.value)
  }
)
```

Fix #7